### PR TITLE
Update with API hooks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
         maven { url  = 'https://plugins.gradle.org/m2/' }
-        maven { url='https://dist.creeper.host/Sponge/maven' }
+        maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
         jcenter()
         mavenCentral()
     }
@@ -19,7 +19,7 @@ apply plugin: 'maven-publish'
 apply plugin: "com.wynprice.cursemaven"
 apply plugin: 'org.spongepowered.mixin'
 
-version = '1.0.1'
+version = '1.0.2'
 group = 'com.minttea.cfbpmmocompat' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'cfbpmmocompat'
 
@@ -102,7 +102,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
+    minecraft 'net.minecraftforge:forge:1.16.5-36.1.31'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
@@ -121,10 +121,8 @@ dependencies {
     // For more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
-    compileOnly fg.deobf("curse.maven:cooking-for-blockheads:3098223")
-    runtimeOnly fg.deobf("curse.maven:cooking-for-blockheads:3098223")
-    compileOnly fg.deobf("curse.maven:project-mmo:3168421")
-    runtimeOnly fg.deobf("curse.maven:project-mmo:3168421")
+    compile fg.deobf("curse.maven:cfb-231484:3330395")
+    compile fg.deobf("curse.maven:pmmo-353935:3359718")
 
 }
 mixin {

--- a/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
+++ b/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
@@ -24,7 +24,7 @@ public class OvenHandler {
         LOGGER.debug("Got UUID, " + uuid);
         if(uuid != null && !world.isRemote)
         {
-            Double award = APIUtils.getXp(input, JType.XP_VALUE_COOK).getOrDefault("cooking", 0);
+            Double award = APIUtils.getXp(input, JType.XP_VALUE_COOK).getOrDefault("cooking", 0d);
             String source = "Cooking " + input.getItem().getRegistryName();
             APIUtils.addXp("cooking", uuid, award, source, false, false);
         }

--- a/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
+++ b/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
@@ -4,6 +4,7 @@ import harmonised.pmmo.config.JType;
 import harmonised.pmmo.events.ChunkDataHandler;
 import harmonised.pmmo.skills.Skill;
 import harmonised.pmmo.util.XP;
+import harmonised.pmmo.api.APIUtils;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -23,11 +24,9 @@ public class OvenHandler {
         LOGGER.debug("Got UUID, " + uuid);
         if(uuid != null && !world.isRemote)
         {
-            ServerPlayerEntity player = XP.getPlayerByUUID(uuid);
-            Double award = XP.getXp(input.getItem().getRegistryName(), JType.XP_VALUE_COOK).get("cooking");
+            Double award = APIUtils.getXp(input.getItem(), JType.XP_VALUE_COOK).getOrDefault("cooking", 0);
             String source = "Cooking " + input.getItem().getRegistryName();
-            XP.awardXp(player, "cooking", null, award, false, false, false);
-
+            APIUtils.addXp("cooking", uuid, award, source, false, false);
         }
     }
 }

--- a/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
+++ b/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
@@ -24,7 +24,7 @@ public class OvenHandler {
         LOGGER.debug("Got UUID, " + uuid);
         if(uuid != null && !world.isRemote)
         {
-            Double award = APIUtils.getXp(input.getItem(), JType.XP_VALUE_COOK).getOrDefault("cooking", 0);
+            Double award = APIUtils.getXp(input, JType.XP_VALUE_COOK).getOrDefault("cooking", 0);
             String source = "Cooking " + input.getItem().getRegistryName();
             APIUtils.addXp("cooking", uuid, award, source, false, false);
         }

--- a/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
+++ b/src/main/java/com/minttea/cfbpmmocompat/OvenHandler.java
@@ -24,7 +24,7 @@ public class OvenHandler {
         LOGGER.debug("Got UUID, " + uuid);
         if(uuid != null && !world.isRemote)
         {
-            Double award = APIUtils.getXp(input.getItem(), JType.XP_VALUE_COOK).getOrDefault("cooking", 0);
+            Double award = APIUtils.getXp(input, JType.XP_VALUE_COOK).getOrDefault("cooking", 0d);
             String source = "Cooking " + input.getItem().getRegistryName();
             APIUtils.addXp("cooking", uuid, award, source, false, false);
         }


### PR DESCRIPTION
This replaces the direct calls to `XP.java` with the calls to the newly added API package methods.  

This should also fix a crash condition I had noticed caused by the method calls being inaccessible.